### PR TITLE
feature: type safe includes

### DIFF
--- a/src/pentagon.ts
+++ b/src/pentagon.ts
@@ -97,7 +97,7 @@ async function deleteImpl<T extends TableDefinition>(
     indexKeys,
     queryArgs.where ?? {},
   );
-
+  // @ts-ignore TODO: delete should not use QueryArgs or QueryResponse
   return await remove(kv, foundItems.map((i) => i.key));
 }
 
@@ -115,7 +115,7 @@ async function deleteManyImpl<T extends TableDefinition>(
     indexKeys,
     queryArgs.where ?? {},
   );
-
+  // @ts-ignore TODO: deleteMany should not use QueryArgs or QueryResponse
   return await remove(kv, foundItems.map((i) => i.key));
 }
 
@@ -149,7 +149,6 @@ async function updateManyImpl<T extends TableDefinition>(
     versionstamp: updateArgs.data.versionstamp ?? existingItem.versionstamp,
   }));
 
-  // @ts-ignore
   return await update(
     kv,
     updatedItems.map((i) => i.value),

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,13 +111,20 @@ type Include<
   ToBeIncluded extends IncludeDetails<Relations> | undefined,
 > = Relations extends Record<string, RelationDefinition>
   ? ToBeIncluded extends Record<string, unknown> ? {
-      [Rel in keyof Relations]: ToBeIncluded extends
-        Record<Rel, infer DetailsToInclude>
-        ? (Relations[Rel][1] extends [{ _output: infer OneToManyRelatedSchema }]
+      [Rel in keyof Relations]: Relations[Rel][1] extends
+        [{ _output: infer OneToManyRelatedSchema }]
+        ? ToBeIncluded extends
+          Record<Rel, infer DetailsToInclude extends Record<string, unknown>>
           ? MatchAndSelect<OneToManyRelatedSchema, DetailsToInclude>[]
-          : Relations[Rel][1] extends { _output: infer OneToOneRelatedSchema }
-            ? MatchAndSelect<OneToOneRelatedSchema, DetailsToInclude>
-          : Nothing)
+        : ToBeIncluded extends Record<Rel, true> ? OneToManyRelatedSchema[]
+        : Nothing
+        : Relations[Rel][1] extends { _output: infer OneToOneRelatedSchema }
+          ? ToBeIncluded extends
+            Record<Rel, infer DetailsToInclude extends Record<string, unknown>>
+            ? ToBeIncluded extends Record<Rel, true>
+              ? MatchAndSelect<OneToOneRelatedSchema, DetailsToInclude>
+            : Nothing
+          : OneToOneRelatedSchema
         : Nothing;
     }
   : Nothing

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,32 +1,55 @@
+/// <reference lib="deno.unstable" />
 import { z } from "../deps.ts";
 import { KeyPropertySchema } from "./keys.ts";
-
 export interface PentagonMethods<T extends TableDefinition> {
-  findFirst: (args: QueryArgs<T>) => Promise<QueryResponse<T, typeof args>>;
+  findFirst: <Args extends QueryArgs<T>>(
+    args: Args,
+  ) => Promise<QueryResponse<T, Args>>;
+
   // findFirstOrThrow: (
   //   args: QueryArgs<T>,
   // ) => QueryResponse<T, typeof args>;
-  findMany: (
-    args: QueryArgs<T>,
-  ) => Promise<Array<QueryResponse<T, typeof args>>>;
+
+  findMany: <Args extends QueryArgs<T>>(
+    args: Args,
+  ) => Promise<Array<QueryResponse<T, Args>>>;
+
   // findUnique: (args: QueryArgs<T>) => QueryResponse<T, typeof args>;
+
   // findUniqueOrThrow: (
   //   args: QueryArgs<T>,
   // ) => QueryResponse<T, typeof args>;
-  create: (args: CreateArgs<T>) => Promise<CreateAndUpdateResponse<T>>;
-  createMany: (
-    args: CreateManyArgs<T>,
+
+  create: <Args extends CreateArgs<T>>(
+    args: Args,
+  ) => Promise<CreateAndUpdateResponse<T>>;
+
+  createMany: <Args extends CreateManyArgs<T>>(
+    args: Args,
   ) => Promise<CreateAndUpdateResponse<T>[]>;
-  update: (args: UpdateArgs<T>) => Promise<CreateAndUpdateResponse<T>>;
-  updateMany: (
-    args: UpdateArgs<T>,
+
+  update: <Args extends UpdateArgs<T>>(
+    args: Args,
+  ) => Promise<CreateAndUpdateResponse<T>>;
+
+  updateMany: <Args extends UpdateArgs<T>>(
+    args: Args,
   ) => Promise<Array<CreateAndUpdateResponse<T>>>;
+
   // upsert: (args: CreateAndUpdateArgs<T>) => CreateAndUpdateResponse<T>;
+
   // count: (args: QueryArgs<T>) => number;
-  delete: (args: QueryArgs<T>) => Promise<QueryResponse<T, typeof args>>;
-  deleteMany: (
-    args: QueryArgs<T>,
-  ) => Promise<QueryResponse<T, typeof args>>;
+
+  // @ts-ignore TODO: delete should not use QueryArgs or QueryResponse
+  delete: <Args extends QueryArgs<T>>(
+    args: Args,
+  ) => Promise<QueryResponse<T, Args>>;
+
+  // @ts-ignore TODO: deleteMany should not use QueryArgs or QueryResponse
+  deleteMany: <Args extends QueryArgs<T>>(
+    args: Args,
+  ) => Promise<QueryResponse<T, Args>>;
+
   // aggregate: (args: QueryArgs<T>) => QueryResponse<T, typeof args>;
 }
 
@@ -60,7 +83,7 @@ export type RelationDefinition = [
    * to-many relation, if it's not an array, then its treated as a
    * to-one relation.
    */
-  relationSchema: ReturnType<typeof z.object>[] | ReturnType<typeof z.object>,
+  relationSchema: [ReturnType<typeof z.object>] | ReturnType<typeof z.object>,
   /**
    * LocalKey is a string if this schema is the one defining the relation,
    * undefined if this schema is the target of the relation.
@@ -78,9 +101,32 @@ export type QueryResponse<
   T extends TableDefinition,
   PassedInArgs extends QueryArgs<T>,
 > = WithVersionstamp<
-  // @todo: these types need fixing
-  z.output<T["schema"]>
->; // & PassedInArgs['include'] extends undefined ? {} : PassedInArgs['include']
+  z.output<T["schema"]> & Include<T["relations"], PassedInArgs["include"]>
+>;
+
+type Include<
+  Relations extends TableDefinition["relations"],
+  ToBeIncluded extends IncludeDetails<Relations> | undefined,
+> = Relations extends Record<string, RelationDefinition> ? {
+    [Rel in keyof Relations]: ToBeIncluded extends
+      Record<Rel, infer DetailsToInclude>
+      ? (Relations[Rel][1] extends [{ _output: infer OneToManyRelatedSchema }]
+        ? MatchAndSelect<OneToManyRelatedSchema, DetailsToInclude>[]
+        : Relations[Rel][1] extends { _output: infer OneToOneRelatedSchema }
+          ? MatchAndSelect<OneToOneRelatedSchema, DetailsToInclude>
+        : never)
+      : ToBeIncluded;
+  }
+  : never;
+
+type MatchAndSelect<SourceSchema, ToBeIncluded> = {
+  [Key in Extract<keyof SourceSchema, keyof ToBeIncluded>]:
+    ToBeIncluded[Key] extends infer ToInclude
+      ? SourceSchema[Key] extends infer Source ? ToInclude extends true ? Source
+        : MatchAndSelect<Source, ToInclude>
+      : never
+      : never;
+};
 
 export type DeleteResponse = { versionstamp: string };
 export type CreateAndUpdateResponse<T extends TableDefinition> =
@@ -106,22 +152,29 @@ export type UpdateArgs<T extends TableDefinition> = QueryArgs<T> & {
 
 export type QueryKvOptions = Parameters<Deno.Kv["get"]>[1];
 
+type IncludeDetails<Relations extends TableDefinition["relations"]> =
+  Relations extends Record<string, RelationDefinition> ? {
+      [Rel in keyof Relations]?:
+        | true
+        | (Relations[Rel][1] extends [{ _output: infer OneToManyRelatedSchema }]
+          ? Includable<OneToManyRelatedSchema>
+          : Relations[Rel][1] extends { _output: infer OneToOneRelatedSchema }
+            ? Includable<OneToOneRelatedSchema>
+          : never);
+    }
+    : never;
+
+type Includable<T> = T extends Record<string, unknown>
+  ? { [K in keyof T]?: true | Includable<T[K]> }
+  : never;
+
 export type QueryArgs<T extends TableDefinition> = {
   where?: Partial<WithMaybeVersionstamp<z.infer<T["schema"]>>>;
   take?: number;
   skip?: number;
   select?: Partial<z.infer<T["schema"]>>;
   orderBy?: Partial<z.infer<T["schema"]>>;
-  include?: {
-    [K in keyof T["relations"]]:
-      | true
-      | Partial<
-        {
-          // @ts-expect-error -> TypeScript wizards, help me fix this!
-          [KK in keyof z.infer<T["relations"][K][1]>]: true;
-        }
-      >;
-  };
+  include?: IncludeDetails<T["relations"]>;
   distinct?: Array<keyof z.infer<T["schema"]>>;
   kvOptions?: QueryKvOptions;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,20 +104,24 @@ export type QueryResponse<
   z.output<T["schema"]> & Include<T["relations"], PassedInArgs["include"]>
 >;
 
+type Nothing = {};
+
 type Include<
   Relations extends TableDefinition["relations"],
   ToBeIncluded extends IncludeDetails<Relations> | undefined,
-> = Relations extends Record<string, RelationDefinition> ? {
-    [Rel in keyof Relations]: ToBeIncluded extends
-      Record<Rel, infer DetailsToInclude>
-      ? (Relations[Rel][1] extends [{ _output: infer OneToManyRelatedSchema }]
-        ? MatchAndSelect<OneToManyRelatedSchema, DetailsToInclude>[]
-        : Relations[Rel][1] extends { _output: infer OneToOneRelatedSchema }
-          ? MatchAndSelect<OneToOneRelatedSchema, DetailsToInclude>
-        : never)
-      : ToBeIncluded;
-  }
-  : never;
+> = Relations extends Record<string, RelationDefinition>
+  ? ToBeIncluded extends Record<string, unknown> ? {
+      [Rel in keyof Relations]: ToBeIncluded extends
+        Record<Rel, infer DetailsToInclude>
+        ? (Relations[Rel][1] extends [{ _output: infer OneToManyRelatedSchema }]
+          ? MatchAndSelect<OneToManyRelatedSchema, DetailsToInclude>[]
+          : Relations[Rel][1] extends { _output: infer OneToOneRelatedSchema }
+            ? MatchAndSelect<OneToOneRelatedSchema, DetailsToInclude>
+          : Nothing)
+        : Nothing;
+    }
+  : Nothing
+  : Nothing;
 
 type MatchAndSelect<SourceSchema, ToBeIncluded> = {
   [Key in Extract<keyof SourceSchema, keyof ToBeIncluded>]:

--- a/test/include_test.ts
+++ b/test/include_test.ts
@@ -24,7 +24,10 @@ Deno.test("include", async (t) => {
       name: "John Doe",
       myOrders: [{
         id: "aaa62b91-a021-41c3-a2ce-ef079859d59c",
-        createdAt: new Date(0),
+        createdAt: {
+          date: new Date(0),
+          userReadable: "1970",
+        },
         userId: "67218087-d9a8-4a57-b058-adc01f179ff9",
         name: "Cheeseburger",
       }],

--- a/test/include_test.ts
+++ b/test/include_test.ts
@@ -22,7 +22,6 @@ Deno.test("include", async (t) => {
       createdAt: new Date(0),
       id: "67218087-d9a8-4a57-b058-adc01f179ff9",
       name: "John Doe",
-      // @ts-expect-error
       myOrders: [{
         id: "aaa62b91-a021-41c3-a2ce-ef079859d59c",
         createdAt: new Date(0),
@@ -38,21 +37,24 @@ Deno.test("include", async (t) => {
       include: {
         myOrders: {
           name: true,
+          createdAt: {
+            userReadable: true
+          }
         },
       },
     });
 
-    // @todo: this shouldn't give TS errors
-    // @ts-expect-error
     const myOrders = userWithPartialOrders.myOrders;
 
     assertEquals(removeVersionstamp(userWithPartialOrders), {
       createdAt: new Date(0),
       id: "67218087-d9a8-4a57-b058-adc01f179ff9",
       name: "John Doe",
-      // @ts-expect-error
       myOrders: [{
         name: "Cheeseburger",
+        createdAt: {
+          userReadable: '1970'
+        }
       }],
     });
   });

--- a/test/util.ts
+++ b/test/util.ts
@@ -9,7 +9,10 @@ export const User = z.object({
 
 export const Order = z.object({
   id: z.string().uuid().describe("primary, unique"),
-  createdAt: z.date(),
+  createdAt: z.object({
+    date: z.date(),
+    userReadable: z.string()
+  }),
   name: z.string(),
   userId: z.string().uuid(),
 });
@@ -63,7 +66,10 @@ export async function populateMockDatabase(
   await db.orders.create({
     data: {
       id: "aaa62b91-a021-41c3-a2ce-ef079859d59c",
-      createdAt: new Date(0),
+      createdAt: {
+        date: new Date(0),
+        userReadable: '1970'
+      },
       userId: "67218087-d9a8-4a57-b058-adc01f179ff9",
       name: "Cheeseburger",
     },


### PR DESCRIPTION
- Implemented type-level logic for including related objects in the query.
- `QueryArgs["include"]` can now handle deeply nested properties.
- Removed several ts-ignore directives.
- **Added ts-ignore directives for `delete` and `deleteMany`**: they share parameter and return types with query operations, which is inaccurate and misleading. `DeleteArgs` and `DeleteResponse` interfaces need to be implemented soon.
- The test `include > specific items` now fails. This is a bug in the implementation that manifests when `QueryArgs["include"]` is deeply nested.